### PR TITLE
Extended /etc/issue reading and parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ PREFIX   := /usr/local
 CFLAGS   += -Wall -pedantic
 CPPFLAGS += -DVERSION=\"$(VERSION)\" -D_XOPEN_SOURCE=500
 LDFLAGS  +=
-LIBS     := -lcrypt
+LIBS     := -lcrypt -lutil
 
 .PHONY: clean install uninstall
 
-SRC := auth.c main.c options.c util.c vt.c
+SRC := auth.c main.c options.c util.c vt.c issue.c
 DEP := $(SRC:.c=.d)
 OBJ := $(SRC:.c=.o)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,28 @@
-## PhysLock but with /etc/issue display support.
+Physlock extended to support displaying /etc/issue
+==================================================
 
-Basically, the same as PhysLock except it reads and shows the contents of whatever is in
-/etc/issue. Cool for awesome ANSI art lock screens. :)
+Basically, the same as Physlock except it reads and shows the contents of
+whatever is in `/etc/issue`. Cool for awesome ANSI art lock screens!
 
-A sample has been provided of Ryu from https://git.io/ryucolor, but adjusted to fit 1080p screens better!
+A sample has been provided of Ryu from https://git.io/ryucolor, but
+adjusted to fit 1080p screens better!
 
-###Original README.md follows...
+Additionally we are able to replace escape sequences, similarly to those
+support by `agetty(8)`, with:
+
+| Escape Sequence | Result |
+| --------------- | ------ |
+| `\m` | Print machine architecture (e.g. `x86_64`) |
+| `\n` | Print machine name |
+| `\r` | Print OS version |
+| `\s` | Print OS name |
+| `\v` | Print OS extra info |
+| `\d` or `\t` | Display date in ISO-8601 format or `HH:MM:SS` |
+| `\l` | Print tty number (e.g. "tty1", etc.) |
+| `\u` or `\U` | Print number of users logged in (including you) |
+
+About
+-----
 
 Control physical access to a linux computer by locking all of its virtual
 terminals / consoles.
@@ -60,3 +77,4 @@ The following command-line arguments are supported:
     -m       mute kernel messages on console while physlock is running
     -s       disable sysrq key while physlock is running
     -v       print version information and exit
+    -z       disable printing the /etc/issue file

--- a/issue.c
+++ b/issue.c
@@ -1,0 +1,133 @@
+/* physlock: issue.c
+ * Copyright (c) 2013 Bert Muennich <be.muennich at gmail.com>
+ *
+ * This file contains functions that are based on agetty(8) by
+ * Peter Orbaek <poe@daimi.aau.dk> and Werner Fink <werner@suse.de>.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <utmpx.h>
+#include <sys/utsname.h>
+#include <langinfo.h>
+#include <time.h>
+#include <errno.h>
+
+#include "config.h"
+#include "util.h"
+#include "issue.h"
+#include "vt.h"
+
+static void handle_special_char(unsigned char c, vt_t vt, int oldvt, FILE *fp)
+{
+    struct utsname uts;
+
+    switch (c) {
+        case 's':
+            uname(&uts);
+            fprintf(vt.ios, "%s", uts.sysname);
+            break;
+        case 'n':
+            uname(&uts);
+            fprintf(vt.ios, "%s", uts.nodename);
+            break;
+        case 'r':
+            uname(&uts);
+            fprintf(vt.ios, "%s", uts.release);
+            break;
+        case 'v':
+            uname(&uts);
+            fprintf(vt.ios, "%s", uts.version);
+            break;
+        case 'm':
+            uname(&uts);
+            fprintf(vt.ios, "%s", uts.machine);
+            break;
+        case 'd':
+        case 't':
+            {
+                time_t now;
+                struct tm *tm;
+
+                time(&now);
+                tm = localtime(&now);
+
+                if (!tm)
+                    break;
+
+                if (c == 'd') /* ISO 8601 */
+                    fprintf(vt.ios,
+                            "%s %s %d  %d",
+                            nl_langinfo(ABDAY_1 + tm->tm_wday),
+                            nl_langinfo(ABMON_1 + tm->tm_mon),
+                            tm->tm_mday,
+                            tm->tm_year < 70 ? tm->tm_year + 2000 :
+                            tm->tm_year + 1900);
+                else
+                    fprintf(vt.ios,
+                            "%02d:%02d:%02d",
+                            tm->tm_hour, tm->tm_min, tm->tm_sec);
+                break;
+            }
+        case 'l':
+            fprintf(vt.ios, "tty%d", oldvt);
+            break;
+        case 'u':
+        case 'U':
+            {
+                int users = 0;
+                struct utmpx *ut;
+                setutxent();
+                while ((ut = getutxent()))
+                    if (ut->ut_type == USER_PROCESS)
+                        users++;
+                endutxent();
+                if (c == 'U')
+                    fprintf(vt.ios, P_("%d user", "%d users", users), users);
+                else
+                    fprintf (vt.ios, "%d ", users);
+                break;
+            }
+        default:
+            fputc(c, vt.ios);
+            break;
+    }
+}
+
+void print_issue_file(vt_t vt, int oldvt)
+{
+    FILE *fd;
+    if ((fd = fopen(ISSUE_FILE_PATH, "r"))) {
+        int c;
+
+        while ((c = getc(fd)) != EOF) {
+            if (c == '\\')
+                handle_special_char(getc(fd), vt, oldvt, fd);  
+            else
+                fputc(c, vt.ios);
+        }
+        fflush(vt.ios);
+        fclose(fd);
+    }
+    else {
+        error(EXIT_FAILURE, errno, "Unable to open %s", ISSUE_FILE_PATH);
+    }
+}

--- a/issue.h
+++ b/issue.h
@@ -1,5 +1,8 @@
-/* physlock: options.h
+/* physlock: issue.h
  * Copyright (c) 2013 Bert Muennich <be.muennich at gmail.com>
+ *
+ * This file contains functions that are based on agetty(8) by
+ * Peter Orbaek <poe@daimi.aau.dk> and Werner Fink <werner@suse.de>.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -15,20 +18,22 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+#ifndef ISSUE_H
+#define ISSUE_H
 
-#ifndef OPTIONS_H
-#define OPTIONS_H
+#include <stdio.h>
 
-typedef struct options_s {
-    int detach;
-    int disable_sysrq;
-    int disable_issue;
-    int lock_switch;
-    int mute_kernel_messages;
-} options_t;
+#include "vt.h"
 
-extern const options_t *options;
+// This sugar makes using singular/plural more simple
+#define P_(singular, plural, n) ((n) == 1 ? (singular) : (plural))
 
-void parse_options(int, char**);
+/*
+ * This function reads and print out the /etc/issue file, replacing escape
+ * sequences like '\l', '\u', and '\t' - in the same manner as agetty(8).
+ * This function only implements a subset of the escape sequences supported
+ * by agetty(8)!!!
+ */
+void print_issue_file(vt_t, int);
 
-#endif /* OPTIONS_H */
+#endif /* ISSUE_H */

--- a/options.c
+++ b/options.c
@@ -28,7 +28,7 @@ static options_t _options;
 const options_t *options = (const options_t*) &_options;
 
 void print_usage() {
-	printf("usage: physlock [-dhLlmsv]\n");
+	printf("usage: physlock [-dhLlmsvz]\n");
 }
 
 void print_version() {
@@ -43,10 +43,11 @@ void parse_options(int argc, char **argv) {
 
 	_options.detach = 0;
 	_options.disable_sysrq = 0;
+	_options.disable_issue = 0;
 	_options.lock_switch = -1;
 	_options.mute_kernel_messages = 0;
 
-	while ((opt = getopt(argc, argv, "dhLlmsv")) != -1) {
+	while ((opt = getopt(argc, argv, "dhLlmsvz")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -72,6 +73,9 @@ void parse_options(int argc, char **argv) {
 			case 'v':
 				print_version();
 				exit(0);
+            case 'z':
+                _options.disable_issue = 1;
+                break;
 		}
 	}
 }

--- a/vt.c
+++ b/vt.c
@@ -152,7 +152,6 @@ void vt_flush(vt_t *vt) {
 
 CLEANUP void vt_reset(vt_t *vt) {
 	fprintf(vt->ios, "\033[H\033[J"); /* clear the screen */
-	fprintf(vt->ios, "Foo!");
 	vt->term.c_lflag = vt->rlflag;
 	tcsetattr(vt->fd, TCSANOW, &vt->term);
 }


### PR DESCRIPTION
In essence, we treat /etc/issue just like agetty(8) does - with some
omissions. Specifically we are able to parse and replace a few escape
sequences like `\l`. The README has been updated to include a list of
what escape sequences are currently supported. Additionally, we have
added the option to disable the printing of /etc/issue.